### PR TITLE
Fix button labels

### DIFF
--- a/arch/arm/dts/qcom/sdm636-asus-x00qd.dts
+++ b/arch/arm/dts/qcom/sdm636-asus-x00qd.dts
@@ -72,7 +72,7 @@
 		};
 
 		key-vol-down {
-			label = "vol_down";
+			label = "Volume Down";
 			gpios = <&tlmm 43 GPIO_ACTIVE_LOW>;
 			linux,input-type = <1>;
 			linux,code = <KEY_VOLUMEDOWN>;

--- a/arch/arm/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm/dts/qcom/sdm636-asus-x00td.dts
@@ -72,7 +72,7 @@
 		};
 
 		key-vol-down {
-			label = "vol_down";
+			label = "Volume Down";
 			gpios = <&tlmm 43 GPIO_ACTIVE_LOW>;
 			linux,input-type = <1>;
 			linux,code = <KEY_VOLUMEDOWN>;

--- a/board/qualcomm/qcom_sdm660_phone.env
+++ b/board/qualcomm/qcom_sdm660_phone.env
@@ -19,7 +19,7 @@ bootmenu_3=Reboot=reset
 bootmenu_4=Power off=poweroff
 menucmd=font select 12x22; bootmenu
 bootcmd=run do_boot; run do_fastboot
-button_cmd_0_name=vol_down
+button_cmd_0_name=Volume Down
 button_cmd_0=run do_fastboot
 button_cmd_1_name=Volume Up
 button_cmd_1=run menucmd


### PR DESCRIPTION
Upstream changed how KPDPWR and RESIN  buttons on PMIC are named - they're now "Power Button" and "Volume Down".

Update environment file and some device DTS to match new reality.
