### PR TITLE
fixup! Add Asus Zenfone Max Pro M1 sdm636 dt and config

### DIFF
--- a/arch/arm/dts/qcom/sdm636-asus-x00td.dts
+++ b/arch/arm/dts/qcom/sdm636-asus-x00td.dts
@@ -10,7 +10,6 @@
 #include "pm660l.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
-#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 
 /delete-node/ &qhee_code;
 /delete-node/ &smem_region;
@@ -59,9 +58,6 @@
 		status = "okay";
 		compatible = "gpio-keys";
 
-		pinctrl-0 = <&vol_up_default>;
-		pinctrl-names = "default";
- 
 		key-vol-up {
 			label = "Volume Up";
 			gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
@@ -303,24 +299,16 @@
 };
 
 &pm660_fg {
-	status = "okay";
 	monitored-battery = <&battery>;
 	power-supplies = <&pm660_charger>;
+
+	status = "okay";
 };
 
 &pm660_rradc {
 	status = "okay";
 };
 
-&pm660l_gpios {
-	vol_up_default: vol-up-default-state {
-		pins = "gpio7";
-		function = PMIC_GPIO_FUNC_NORMAL;
-		bias-pull-up;
-		input-enable;
-		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
-	};
-};
 
 &pm660l_wled {
 	default-brightness = <512>;


### PR DESCRIPTION
asus-x00td has volume up/down buttons in TLMM GPIOs
Not in PMIC GPIO 