### PR TITLE
Fixes for mmc resetting and missing DT bits for base dtsi and lavender

### DIFF
--- a/drivers/clk/qcom/clock-sdm660.c
+++ b/drivers/clk/qcom/clock-sdm660.c
@@ -248,13 +248,8 @@ static const struct qcom_reset_map sdm660_gcc_resets[] = {
 	[GCC_USB_20_BCR] = { 0x2f000 },
 	[GCC_USB_30_BCR] = { 0xf000 },
 	[GCC_USB_PHY_CFG_AHB2PHY_BCR] = { 0x6a000 },
-	/*
-	 * Linux dt-bindings (and sdm630 dtsi) don't have the defines for
-	 * (or uses of) GCC_SDCCn_BCR resets, so this won't compile,
-	 * but the hardware exists and their offsets are:
-	 */
-	/* [GCC_SDCC1_BCR] = { 0x16000 }, */
-	/* [GCC_SDCC2_BCR] = { 0x14000 }, */
+	[GCC_SDCC1_BCR] = { 0x16000 },
+	[GCC_SDCC2_BCR] = { 0x14000 },
 };
 
 static const struct qcom_power_map sdm660_gdscs[] = {

--- a/dts/upstream/include/dt-bindings/clock/qcom,gcc-sdm660.h
+++ b/dts/upstream/include/dt-bindings/clock/qcom,gcc-sdm660.h
@@ -153,5 +153,7 @@
 #define GCC_USB_30_BCR			7
 #define GCC_USB_PHY_CFG_AHB2PHY_BCR	8
 #define GCC_MSS_RESTART			9
+#define GCC_SDCC1_BCR			10
+#define GCC_SDCC2_BCR			11
 
 #endif

--- a/dts/upstream/src/arm64/qcom/sdm630.dtsi
+++ b/dts/upstream/src/arm64/qcom/sdm630.dtsi
@@ -1379,6 +1379,7 @@
 					<&xo_board>;
 			clock-names = "iface", "core", "xo";
 
+			resets = <&gcc GCC_SDCC2_BCR>;
 
 			interconnects = <&a2noc 3 &a2noc 10>,
 					<&gnoc 0 &cnoc 28>;
@@ -1432,6 +1433,8 @@
 				 <&xo_board>,
 				 <&gcc GCC_SDCC1_ICE_CORE_CLK>;
 			clock-names = "iface", "core", "xo", "ice";
+
+			resets = <&gcc GCC_SDCC1_BCR>;
 
 			interconnects = <&a2noc 2 &a2noc 10>,
 					<&gnoc 0 &cnoc 27>;

--- a/dts/upstream/src/arm64/qcom/sdm660-xiaomi-lavender.dts
+++ b/dts/upstream/src/arm64/qcom/sdm660-xiaomi-lavender.dts
@@ -418,6 +418,8 @@
 &sdhc_2 {
 	status = "okay";
 
+	cd-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+
 	vmmc-supply = <&vreg_l5b_2p95>;
 	vqmmc-supply = <&vreg_l2b_2p95>;
 };


### PR DESCRIPTION
* Cherry pick commits from upstream to add missing eMMC/SD card block resets.
* Add missing cd-gpios for lavender dts (patch pending upstream)
* Uncomment resets in clock gcc-sdm660 driver

logs with debug prints enabled: https://paste.sr.ht/~minlexx/61b160fc8eb86305b9708f25c783c25233738bbe