### PR TITLE
Add menu entry to dump raw value of GPU speedbin efuse

### DIFF
--- a/board/qualcomm/qcom_sdm660_phone.env
+++ b/board/qualcomm/qcom_sdm660_phone.env
@@ -39,8 +39,9 @@ bootmenu_2=Boot from SD card=run do_boot_sd
 bootmenu_3=Fastboot mode=run do_fastboot
 bootmenu_4=USB Mass Storage mode=run do_ums
 bootmenu_5=Dump bootargs=fdt addr $prevbl_fdt_addr; fdt print /chosen bootargs; pause
-bootmenu_6=Reboot=reset
-bootmenu_7=Power off=poweroff
+bootmenu_6=Dump GPU sppedbin efuse=echo "*** contents of speedbin efuse (raw): ***"; md.l 0x7841a0 1; pause
+bootmenu_7=Reboot=reset
+bootmenu_8=Power off=poweroff
 
 # Hold buttons during boot to trigger various actions
 button_cmd_0_name=Volume Down


### PR DESCRIPTION
Add menu entry to print the value of `QFPROM_CORR_FEAT_CONFIG_ROW0_LSB` register that contains GPU speedbin in bits `[21-28]` (`GFX3D_FREQ_LIMIT_VAL BIT[28:21]`)

To calculate the speedbin value used in [downstream in sdm660-gpu.dtsi](https://github.com/LineageOS/android_kernel_xiaomi_sdm660/blob/lineage-20/arch/arm64/boot/dts/vendor/qcom/sdm660-gpu.dtsi#L437)  (but something different is used in mainline opp-tables), you need to do the computation
```
speedbin = (QFPROM_CORR_FEAT_CONFIG_ROW0_LSB & 0x1fe00000) >> 21
```
