### PR TITLE
button: qcom-pmic: allow to specify code in devicetree

### DIFF
--- a/drivers/button/button-qcom-pmic.c
+++ b/drivers/button/button-qcom-pmic.c
@@ -143,6 +143,21 @@ static int qcom_pwrkey_probe(struct udevice *dev)
 
 	priv->base = base;
 
+	ret = dev_read_u32(dev, "linux,code", &priv->code);
+	if (ret == 0) {
+		/* convert key, if read OK */
+		switch (priv->code) {
+		case KEY_VOLUMEDOWN:
+			priv->code = KEY_DOWN;
+			uc_plat->label = "Volume Down";
+			break;
+		case KEY_VOLUMEUP:
+			priv->code = KEY_UP;
+			uc_plat->label = "Volume Up";
+			break;
+		}
+	}
+
 	/* Do a sanity check */
 	ret = pmic_reg_read(priv->pmic, priv->base + REG_TYPE);
 	if (ret != 0x1 && ret != 0xb) {


### PR DESCRIPTION
Most device vendors put "Volume Down" button onto PMIC RESIN. But Sony is special: see
`dts/upstream/src/arm64/qcom/sdm630-sony-xperia-nile.dtsi` or [1]. They put "Volume Down" on PMIC GPIO 7 where others usually put "Volume Up", and `KEY_VOLUMEUP` is inside `&pon_resin`.

Currently if you boot U-Boot on such Sony device, you end up with 2 "Volume Down" buttons, and no "Volume Up", which makes navigating menu problematic.

Support reading devicetree "linux,code" property and override statically defined button code & label based on that.

[1] https://elixir.bootlin.com/linux/v6.15-rc3/source/arch/arm64/boot/dts/qcom/sdm630-sony-xperia-nile.dtsi#L263