### PR TITLE
Sony Xperia XA2 port (sdm630-sony-nile-pioneer)

### DIFF
--- a/configs/qcom_sdm630_sony_nile_defconfig
+++ b/configs/qcom_sdm630_sony_nile_defconfig
@@ -1,0 +1,38 @@
+# Configuration for building U-Boot as 2nd stage
+# bootloader to be flashed as part of boot.img to
+# boot partition on Sony Xperia XA2 phones.
+
+#include "qcom_sdm660_defconfig"
+
+# sony-nile platform device trees are upstream
+CONFIG_OF_UPSTREAM=y
+CONFIG_DEFAULT_DEVICE_TREE="qcom/sdm630-sony-xperia-nile-pioneer"
+
+# Sony logo is black on white background. Very annoying.
+# Clear framebuffer.
+CONFIG_NO_FB_CLEAR=n
+
+# This is built with no real serial debug uart available,
+# it is using ramoops logging instead
+
+# CONFIG_REQUIRE_SERIAL_CONSOLE is not set
+# CONFIG_SERIAL_PRESENT is not set
+# ^^ reason to disable both debug-uart and bluetooth-uart nodes in dts
+
+# Values from pioneer downstream /sys/module/ramoops/parameters/
+# NOTE: Doesn't match what's in mainline Linux dts.
+#       Linux won't be able to read our logs.
+# console_size	262144		0x40000
+# ftrace_size	0		0x0
+# mem_address	4290772992	0xffc00000
+# mem_size	1048576		0x100000
+# pmsg_size	0		0x0
+# record_size	4096		0x1000
+CONFIG_DEBUG_UART_RAMOOPS=y
+CONFIG_DEBUG_UART_RAMOOPS_BASE=0xffc00000
+CONFIG_DEBUG_UART_RAMOOPS_SIZE=0x100000
+CONFIG_DEBUG_UART_RAMOOPS_CONSOLE_SIZE=0x40000
+CONFIG_DEBUG_UART_RAMOOPS_FTRACE_SIZE=0x0
+CONFIG_DEBUG_UART_RAMOOPS_RECORD_SIZE=0x1000
+CONFIG_DEBUG_UART_RAMOOPS_PMSG_SIZE=0x0
+CONFIG_DEBUG_UART_SKIP_INIT=n

--- a/dts/upstream/src/arm64/qcom/sdm630-sony-xperia-nile.dtsi
+++ b/dts/upstream/src/arm64/qcom/sdm630-sony-xperia-nile.dtsi
@@ -11,6 +11,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/input/gpio-keys.h>
 #include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 
 / {
 	/* required for bootloader to select correct board */
@@ -20,13 +21,13 @@
 
 	/* This part enables graphical output via bootloader-enabled display */
 	chosen {
-		bootargs = "earlycon=tty0 console=tty0";
+		//bootargs = "earlycon=tty0 console=tty0";
 
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
 
-		stdout-path = "framebuffer0";
+		//stdout-path = "framebuffer0";
 
 		framebuffer0: framebuffer@9d400000 {
 			compatible = "simple-framebuffer";
@@ -90,7 +91,7 @@
 
 	gpio-keys {
 		compatible = "gpio-keys";
-		pinctrl-0 = <&gpio_keys_default>;
+		pinctrl-0 = <&gpio_keys_default &vol_down_default>;
 		pinctrl-names = "default";
 
 		key-camera-focus {
@@ -127,11 +128,11 @@
 		ramoops@ffc00000 {
 			compatible = "ramoops";
 			reg = <0x0 0xffc00000 0x0 0x100000>;
-			record-size = <0x10000>;
-			console-size = <0x60000>;
-			ftrace-size = <0x10000>;
-			pmsg-size = <0x20000>;
-			ecc-size = <16>;
+			record-size = <0x1000>;
+			console-size = <0x40000>;
+			ftrace-size = <0>;
+			pmsg-size = <0>;
+			ecc-size = <0>;
 			status = "okay";
 		};
 
@@ -203,15 +204,25 @@
 };
 
 &blsp1_uart2 {
-	status = "okay";
+	status = "disbled"; // "okay";
 
 	/* MSM serial console */
 };
 
 &blsp2_uart1 {
-	status = "okay";
+	status = "disbled"; // "okay";
 
 	/* HCI Bluetooth */
+};
+
+&pm660l_gpios {
+	vol_down_default: vol-down-default-state {
+		pins = "gpio7";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-pull-up;
+		input-enable;
+		qcom,drive-strength = <PMIC_GPIO_STRENGTH_NO>;
+	};
 };
 
 &pm660l_lpg {
@@ -625,6 +636,8 @@
 
 &sdhc_2 {
 	status = "okay";
+
+	cd-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	vmmc-supply = <&vreg_l5b_2p95>;
 	vqmmc-supply = <&vreg_l2b_2p95>;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2dd6d068-ad4f-49f3-bb92-73ebe9467f1e)

Didn't test the ramoops (no recovery partition to reboot to twrp?), other things work, even Camera Snapshot key (where is Camera Focus key, I don't know)

`qcom/sdm630-sony-xperia-nile-pioneer.dts` is already upstream, so aplying fixups on top of it is a bit of dirty hack. Some of those *should* go upstream:
* addition of `vol_down_default` pinctrl state - we need to describe pm660l_gpios pin 7
* addition of `cd-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;`