### PR TITLE
Fix "Boot from eMMC" / "Boot from SD card" menu entires

### DIFF
--- a/board/qualcomm/qcom_sdm660_phone.env
+++ b/board/qualcomm/qcom_sdm660_phone.env
@@ -32,7 +32,7 @@ fastboot.variant=SDM EMMC
 #   stuck at the console with no way to type
 menucmd=setenv bootcmd run menucmd; \
         font select 12x22; \
-        bootmenu -1
+        bootmenu
 bootmenu_0=Boot first available device (eMMC -> SD)=run do_boot
 bootmenu_1=Boot from eMMC=run do_boot_emmc
 bootmenu_2=Boot from SD card=run do_boot_sd


### PR DESCRIPTION
Specifying delay of -1 makes bootflow scan to wait for user input, saying "enter option number" but our phones don't have keyboard (usually)