### PR TITLE
console_ramoops: silence too verbose debug print

### DIFF
--- a/common/console_ramoops.c
+++ b/common/console_ramoops.c
@@ -174,7 +174,7 @@ static struct persistent_ram_zone *persistent_ram_new(phys_addr_t start, size_t 
 				prz->buffer->size, prz->buffer->start);
 			persistent_ram_zap(prz);
 		} else {
-			log_info("reusing existing buffer: size %u, start %u\n",
+			log_debug("reusing existing buffer: size %u, start %u\n",
 				 prz->buffer->size, prz->buffer->start);
 		}
 	} else {


### PR DESCRIPTION
It's spamming logs with not very useful info
