### PR TITLE
dts: qcom: sdm660-bbry-athena-boe: typo fix

### DIFF
--- a/arch/arm/dts/qcom/sdm660-bbry-athena-boe.dts
+++ b/arch/arm/dts/qcom/sdm660-bbry-athena-boe.dts
@@ -4,6 +4,6 @@
 
 / {
 	model = "BlackBerry KEY2";
-	compatible = "bbry,athena-boe", "qcom,sdm660",
+	compatible = "bbry,athena-boe", "qcom,sdm660";
 	chassis-type = "handset";
-}
+};


### PR DESCRIPTION
code was recently merged in https://github.com/sdm660-mainline/u-boot/pull/30