### PR TITLE
Set up userdata subpartitions using blkmap

### DIFF
--- a/board/qualcomm/qcom-sdm660-phone.config
+++ b/board/qualcomm/qcom-sdm660-phone.config
@@ -1,6 +1,10 @@
 # Phone-friendly environment
 CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="board/qualcomm/qcom-sdm660-phone.env"
 
+# Support for subpartitions (postmarketOS-style rootfs image containing two subpartitions)
+CONFIG_BLKMAP=y
+CONFIG_CMD_BLKMAP=y
+
 # Support booting Android boot images
 CONFIG_BOOTMETH_ANDROID=y
 CONFIG_CMD_ABOOTIMG=y
@@ -21,6 +25,8 @@ CONFIG_SD_BOOT=y
 CONFIG_QCOM_UFS=n
 # MMC HS200 works perfectly fine here
 CONFIG_MMC_HS200_SUPPORT=y
+# Useful for debugging SMBIOS data
+CONFIG_CMD_SMBIOS=y
 # TODO: This should be in qcom_defconfig once clk driver is upstream
 CONFIG_CLK_QCOM_SDM660=y
 

--- a/board/qualcomm/qcom-sdm660-phone.env
+++ b/board/qualcomm/qcom-sdm660-phone.env
@@ -1,8 +1,16 @@
+bootdelay=0
+bootretry=1
 stdin=serial,button-kbd
 stdout=serial,vidconsole,ramoops
 stderr=serial,vidconsole,ramoops
+
+# Set up a block map pointing to our userdata partition
+setup_rootdev=if scsi device 0; then setenv rootdev scsi 0; else mmc rescan; setenv rootdev mmc 1; fi
+setup_blkmap=part start ${rootdev} userdata userdata_start; part size ${rootdev} userdata userdata_size; blkmap create root; blkmap map root 0 0x${userdata_size} linear ${rootdev} 0x${userdata_start}
+
 preboot=font select 8x16; \
-        echo "Hold Volume down to enter fastboot, Volume up to enter menu"; \
+        echo "*** Hold Volume down to enter fastboot, Volume up to enter menu ***"; \
+        run setup_rootdev; run setup_blkmap; \
         sleep 0.5; \
         button list; \
         ufetch; \
@@ -11,22 +19,32 @@ preboot=font select 8x16; \
 # booting
 boot_targets=mmc1 mmc2
 bootmeths=extlinux efi_mgr
-bootcmd=run do_boot; run do_fastboot
-#do_boot=bootefi bootmgr
+
+# bootretry will run this command over and over, if we fail once
+# then bail out to the boot menu instead (with a pause to read
+# the error message)
+bootcmd=run do_boot; pause; run menucmd
+
 do_boot=setenv boot_targets mmc1 mmc2; bootflow scan -lb
 do_boot_emmc=setenv boot_targets mmc1; bootflow scan -lb
 do_boot_sd=setenv boot_targets mmc2; bootflow scan -lb
 do_fastboot=echo "*** Fastboot mode ***"; \
         font select 8x16; \
         fastboot -l $fastboot_addr_r usb 0
-do_ums=echo "*** USB Mass Storage mode ***"; \
+
+do_ums=echo "*** USB Mass Storage mode (eMMC) ***"; \
         echo "*** (press any key to exit) ***"; \
         font select 8x16; \
         ums 0 mmc 1
-do_ums_sd=echo "*** USB Mass Storage mode ***"; \
+do_ums_sd=echo "*** USB Mass Storage mode (SD card) ***"; \
         echo "*** (press any key to exit) ***"; \
         font select 8x16; \
         ums 0 mmc 2
+do_ums_blkmap=echo "*** USB Mass Storage mode (subpartitions) ***"; \
+        echo "*** (press any key to exit) ***"; \
+        font select 8x16; \
+        ums 0 blkmap 0
+
 serial_gadget=setenv stdin serial,button-kbd,usbacm; \
        setenv stdout vidconsole,ramoops,usbacm; \
        setenv stderr vidconsole,ramoops,usbacm; \
@@ -43,18 +61,19 @@ fastboot.variant=SDM EMMC
 #   stuck at the console with no way to type
 menucmd=setenv bootcmd run menucmd; \
         font select 12x22; \
-        bootmenu
+        bootmenu -1
 bootmenu_0=Boot first available device (eMMC -> SD)=run do_boot
 bootmenu_1=Boot from eMMC=run do_boot_emmc
 bootmenu_2=Boot from SD card=run do_boot_sd
 bootmenu_3=Fastboot mode=run do_fastboot
 bootmenu_4=USB Mass Storage mode=run do_ums
 bootmenu_5=USB Mass Storage mode (SD Card)=run do_ums_sd
-bootmenu_6=USB Serial Gadget=run serial_gadget
-bootmenu_7=Dump bootargs=fdt addr $prevbl_fdt_addr; fdt print /chosen bootargs; pause
-bootmenu_8=Dump GPU speedbin efuse=echo "*** contents of speedbin efuse (raw): ***"; md.l 0x7841a0 1; pause
-bootmenu_9=Reboot=reset
-bootmenu_10=Power off=poweroff
+bootmenu_6=USB mass storage mode (subpartitions)=run do_ums_blkmap
+bootmenu_7=USB Serial Gadget=run serial_gadget
+bootmenu_8=Dump bootargs=fdt addr $prevbl_fdt_addr; fdt print /chosen bootargs; pause
+bootmenu_9=Dump GPU speedbin efuse=echo "*** contents of speedbin efuse (raw): ***"; md.l 0x7841a0 1; pause
+bootmenu_10=Reboot=reset
+bootmenu_11=Power off=poweroff
 
 # Hold buttons during boot to trigger various actions
 button_cmd_0_name=Volume Down

--- a/cmd/blkmap.c
+++ b/cmd/blkmap.c
@@ -35,8 +35,8 @@ static int do_blkmap_map_linear(struct map_ctx *ctx, int argc,
 	if (argc < 4)
 		return CMD_RET_USAGE;
 
-	ldevnum = dectoul(argv[2], NULL);
-	lblknr = dectoul(argv[3], NULL);
+	ldevnum = simple_strtoul(argv[2], NULL, 0);
+	lblknr = simple_strtoul(argv[3], NULL, 0);
 
 	lbd = blk_get_devnum_by_uclass_idname(argv[1], ldevnum);
 	if (!lbd) {


### PR DESCRIPTION
Import several improvements from U-Boot Tauchgang (while adapting
them for SDM660) to allow our U-Boot to boot from postmarketOS-style
rootfs setup (single image on userdata partition with subpartitions).

Several other small improvements to boot menu entries:
* add entry to expose subpartitions to USB Mass Storage
* improved timeout handling to properly stop autobooting when bootmenu is started